### PR TITLE
Add `concat()` method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -926,6 +926,19 @@ Collection.prototype.concat = function (collection) {
   return this;
 };
 
+Collection.prototype[Symbol.iterator] = function () {
+  let index = 0;
+
+  return {
+    next: function () {
+      return {
+        value: this.items[index++],
+        done: index > this.items.length
+      }
+    }.bind(this)
+  }
+};
+
 module.exports = function (collection) {
   return new Collection(collection);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -920,7 +920,7 @@ Collection.prototype.concat = function (collection) {
   }
 
   for (let iterator = 1; iterator <= collection.count(); iterator++) {
-    this.items.push(collection[iterator]));
+    this.items.push(collection[iterator]);
   }
 
   return this;

--- a/src/index.js
+++ b/src/index.js
@@ -918,9 +918,11 @@ Collection.prototype.concat = function (collection) {
   if (collection instanceof Collection) {
     collection = collection.all();
   }
-
-  for (let iterator = 1; iterator <= collection.count(); iterator++) {
-    this.items.push(collection[iterator]);
+  
+  if (Array.isArray(collection) || typeof o === 'object') {
+    for (let iterator = 1; iterator <= collection.count(); iterator++) {
+      this.items.push(collection[iterator]);
+    }
   }
 
   return this;

--- a/src/index.js
+++ b/src/index.js
@@ -914,6 +914,18 @@ Collection.prototype.all = function () {
   return this.items;
 };
 
+Collection.prototype.concat = function (collection) {
+  if (collection instanceof Collection) {
+    collection = collection.all();
+  }
+
+  for (let iterator = 1; iterator <= collection.count(); iterator++) {
+    this.items.push(collection[iterator]));
+  }
+
+  return this;
+};
+
 module.exports = function (collection) {
   return new Collection(collection);
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -1637,4 +1637,75 @@ describe('Collect.js Test Suite', function () {
     expect(tapped).to.eql([2, 3, 4, 5]);
     expect(number).to.eql(1);
   });
+  
+    
+  it('should append arrays to collection', function () {
+    const expected = [
+      4,
+      5,
+      6,
+      'a',
+      'b',
+      'c',
+      'Jonny',
+      'from',
+      'Laroe',
+      'Jonny',
+      'from',
+      'Laroe'
+    ];
+
+    const firstCollection = collect([4, 5, 6]);
+    const firstArray = ['a', 'b', 'c'];
+    const secondArray = [{
+      who: 'Jonny'
+    }, {
+      preposition: 'from'
+    }, {
+      where: 'Laroe'
+    }];
+
+    firstCollection
+      .concat(secondCollection)
+      .concat(firstArray)
+      .concat(secondArray);
+
+    expect(firstCollection.count()).to.eql(12);
+    expect(firstCollection.all()).to.eql(expected);
+  });
+
+  it('should append collections to collection', function () {
+    const expected = [
+      4,
+      5,
+      6,
+      'a',
+      'b',
+      'c',
+      'Jonny',
+      'from',
+      'Laroe',
+      'Jonny',
+      'from',
+      'Laroe'
+    ];
+
+    const firstCollection = collect([4, 5, 6]);
+    const secondCollection = collect(['a', 'b', 'c']);
+    const thirdCollection = collect([{
+      who: 'Jonny'
+    }, {
+      preposition: 'from'
+    }, {
+      where: 'Laroe'
+    }]);
+
+    firstCollection
+      .concat(secondCollection)
+      .concat(thirdCollection)
+      .concat(thirdCollection);
+
+    expect(firstCollection.count()).to.eql(12);
+    expect(firstCollection.all()).to.eql(expected);
+  });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1708,4 +1708,23 @@ describe('Collect.js Test Suite', function () {
     expect(firstCollection.count()).to.eql(12);
     expect(firstCollection.all()).to.eql(expected);
   });
+
+  it('should be iterable', function () {
+    let result = '';
+
+    for (let item of collect([1, 2, 3, 4, 5])) {
+      result += item;
+    }
+
+    expect(result).to.eql('12345');
+
+    const result2 = [];
+    const clubs = collect([{ name: 'Liverpool' }, { name: 'Arsenal' }, { name: 'Chelsea' }]);
+
+    for (let club of clubs) {
+      result2.push(club);
+    }
+
+    expect(result2).to.eql(clubs.all());
+  });
 });


### PR DESCRIPTION
New method from a recent Laravel 5.4 patch. I'm not familiar with testing in Javascript, so I have put in some initial work to what I think it should be. Would you mind helping me a bit on this PR to flesh out the testing and make sure the implementation is working as expected?

Looking forward to your feedback :)

Thanks for creating this package! I have been thinking it would be great to have a package like this for a few years. Good to see someone better than me with Javascript took the initiative. :)