### PR TITLE
add support for non-number type in `sum`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,19 +39,19 @@ Collection.prototype.unique = function (key) {
 };
 
 Collection.prototype.sum = function (key) {
-  let total = 0;
+  let total;
 
   if (typeof key === 'undefined') {
     for (let i = 0; i < this.items.length; i++) {
-      total += this.items[i];
+      total = i ? total + this.items[i] : this.items[i];
     }
   } else if (typeof key === 'function') {
     for (let i = 0; i < this.items.length; i++) {
-      total += key(this.items[i]);
+      total = i ? total + key(this.items[i]) : key(this.items[i]);
     }
   } else {
     for (let i = 0; i < this.items.length; i++) {
-      total += this.items[i][key];
+      total = i ? total + this.items[i][key] : this.items[i][key];
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,20 +38,21 @@ Collection.prototype.unique = function (key) {
   return new Collection(collection);
 };
 
-Collection.prototype.sum = function (key) {
-  let total;
+Collection.prototype.sum = function (key, initial_value) {
+  let total = initial_value;
+  let inited = typeof initial_value !== 'undefined';
 
   if (typeof key === 'undefined') {
     for (let i = 0; i < this.items.length; i++) {
-      total = i ? total + this.items[i] : this.items[i];
+      total = i || inited ? total + this.items[i] : this.items[i];
     }
   } else if (typeof key === 'function') {
     for (let i = 0; i < this.items.length; i++) {
-      total = i ? total + key(this.items[i]) : key(this.items[i]);
+      total = i || inited ? total + key(this.items[i]) : key(this.items[i]);
     }
   } else {
     for (let i = 0; i < this.items.length; i++) {
-      total = i ? total + this.items[i][key] : this.items[i][key];
+      total = i || inited ? total + this.items[i][key] : this.items[i][key];
     }
   }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -44,6 +44,8 @@ describe('Collect.js Test Suite', function () {
 
   it('should return the sum of collection values', function () {
     expect(collect([1, 3, 3, 7]).sum()).to.eql(14);
+    expect(collect(['1', 3, 3, 7]).sum()).to.eql('1337');
+    expect(collect([1, 3, 3, '7']).sum()).to.eql('77');
     expect(collect([1, 3, 3, 7]).unique().sum()).to.eql(11);
 
     const collection2 = collect([

--- a/test/tests.js
+++ b/test/tests.js
@@ -46,6 +46,7 @@ describe('Collect.js Test Suite', function () {
     expect(collect([1, 3, 3, 7]).sum()).to.eql(14);
     expect(collect(['1', 3, 3, 7]).sum()).to.eql('1337');
     expect(collect([1, 3, 3, '7']).sum()).to.eql('77');
+    expect(collect([1, 3, 3, 7]).sum(void(0), '')).to.eql('1337');
     expect(collect([1, 3, 3, 7]).unique().sum()).to.eql(11);
 
     const collection2 = collect([


### PR DESCRIPTION
originally `sum` uses 0 as initial value to accumulate
then for non-number type, it behaves wrongly
```javascript
collect(['1', '2', '3']).sum()
//=> '0123'
```
I modify it to use first value as initial value so that
`sum` will behave correctly if all types of values are
same and/or accumulatable

there is `implode` for better joining string but as
`sum` does not report a error, it should be able to deal
with such situation