### PR TITLE
Added babel to transpile to ES5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
   "name": "collect.js",
   "version": "3.0.7",
   "description": "Convenient and dependency free wrapper for working with arrays and objects.",
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha test/tests.js"
+    "test": "node_modules/.bin/mocha test/tests.js",
+    "prepublishOnly": "node_modules/babel-cli/bin/babel.js src --out-dir lib"
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
   },
   "repository": {
     "type": "git",
@@ -40,6 +46,9 @@
   },
   "homepage": "https://github.com/ecrmnn/collect.js",
   "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
+    "babel-preset-es2015": "^6.24.1",
     "benchmark": "^2.1.0",
     "chai": "^3.5.0",
     "mocha": "^2.4.5"


### PR DESCRIPTION
Now transpile to ES5 to avoid any bug with UglifyJS will come to minify the modules as UglifyJS can't understand ES6.