### PR TITLE
Fix sorting numbers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -748,7 +748,11 @@ Collection.prototype.sort = function (fn) {
   const collection = [].concat(this.items);
 
   if (fn === undefined) {
-    collection.sort();
+    if (this.every(item => typeof item === 'number')) {
+      collection.sort((a, b) => a - b);
+    } else {
+      collection.sort();
+    }
   } else {
     collection.sort(fn);
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -1361,12 +1361,12 @@ describe('Collect.js Test Suite', function () {
   });
 
   it('should sort the collection', function () {
-    const collection = collect([5, 3, 1, 2, 4]);
+    const collection = collect([5, 3, 1, 2, 10, 4]);
 
     const sorted = collection.sort();
 
-    expect(sorted.all()).to.eql([1, 2, 3, 4, 5]);
-    expect(collection.all()).to.eql([5, 3, 1, 2, 4]);
+    expect(sorted.all()).to.eql([1, 2, 3, 4, 5, 10]);
+    expect(collection.all()).to.eql([5, 3, 1, 2, 10, 4]);
 
     const collection2 = collect([5, 3, 1, 2, 4]);
 


### PR DESCRIPTION
If we use built-in `sort` method on number array, something is wrong.
```javascript
[2, 10, 1].sort()
// [1, 10, 2]
```

So we should use a callback:
```javascript
[2, 10, 1].sort((a, b) => a - b)
// [1, 2, 10]
```