### PR TITLE
Return early when possible

### DIFF
--- a/src/methods/every.js
+++ b/src/methods/every.js
@@ -1,5 +1,10 @@
 'use strict';
 
 module.exports = function every(fn) {
-  return this.items.filter(fn).length === this.items.length;
+  for (let i = 0; i < this.items.length; i++) {
+    if (!fn(this.items[i])) {
+      return false;
+    }
+    return true;
+  }
 };

--- a/src/methods/first.js
+++ b/src/methods/first.js
@@ -2,7 +2,13 @@
 
 module.exports = function first(fn) {
   if (typeof fn === 'function') {
-    return this.items.filter(fn)[0];
+    for (let i = 0; i < this.items.length; i++) {
+      const item = this.items[i];
+      if (fn(item)) {
+        return item;
+      }
+    }
+    return;
   }
 
   return this.items[0];

--- a/src/methods/has.js
+++ b/src/methods/has.js
@@ -2,11 +2,12 @@
 
 module.exports = function has(key) {
   if (Array.isArray(this.items)) {
-    return (
-      this.items.filter(function(item) {
-        return item.hasOwnProperty(key);
-      }).length > 0
-    );
+    for (let i = 0; i < this.items.length; i++) {
+      if (this.items[i].hasOwnProperty(key)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   return this.items.hasOwnProperty(key);


### PR DESCRIPTION
`filter` is expensive when not needed -- it is not lazy, so it builds an entire result array and has no early abort.

`first`, `every`, and `has` are much faster if they return as early as possible, especially in pathological cases like:
```js
collect([1, 2, 2, 2, 2, ..., 2]).every(x => x === 1);
```