### PR TITLE
group by: allow complex keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "benchmark": "^2.1.0",
     "chai": "^3.5.0",
     "mocha": "^2.4.5"
+  },
+  "dependencies": {
+    "group-by-object": "^1.2.4"
   }
 }

--- a/src/methods/groupBy.js
+++ b/src/methods/groupBy.js
@@ -1,7 +1,7 @@
 'use strict';
 const groupByObject = require('group-by-object');
 
-module.exports = function groupBy(key, complexKeys = false) {
+module.exports = function groupBy(key, complexKeys) {
   if (!complexKeys) {
     let collection = {};
 

--- a/src/methods/groupBy.js
+++ b/src/methods/groupBy.js
@@ -1,23 +1,35 @@
 'use strict';
+const groupByObject = require('group-by-object');
 
-module.exports = function groupBy(key) {
-  let collection = {};
+module.exports = function groupBy(key, complexKeys = false) {
+  if (!complexKeys) {
+    let collection = {};
 
-  this.items.forEach(function(item, index) {
-    let resolvedKey;
+    this.items.forEach(function(item, index) {
+      let resolvedKey;
 
+      if (typeof key === 'function') {
+        resolvedKey = key(item, index);
+      } else {
+        resolvedKey = item[key];
+      }
+
+      if (!collection.hasOwnProperty(resolvedKey)) {
+        collection[resolvedKey] = [];
+      }
+
+      collection[resolvedKey].push(item);
+    });
+
+    return new this.constructor(collection);
+  } else {
+    let fn
     if (typeof key === 'function') {
-      resolvedKey = key(item, index);
+      fn = key
     } else {
-      resolvedKey = item[key];
+      fn = item => item[key]
     }
-
-    if (!collection.hasOwnProperty(resolvedKey)) {
-      collection[resolvedKey] = [];
-    }
-
-    collection[resolvedKey].push(item);
-  });
-
-  return new this.constructor(collection);
+    const map = groupByObject(this.items, fn)
+    return new this.constructor(Array.from(map))
+  }
 };


### PR DESCRIPTION
Hi. I usually have to build dictionaries with complex keys (objects, etc) and using simple objects isn't sufficient since they only allow for `string` keys. A few months ago I built a [very small library](https://github.com/rhyek/group-by-object) that uses `Map`s to help with this and I offer it to you now if you see any use for this functionality:

```js
const people = [
  { id: 1, name: 'John', age: 40, genre: 'Rock' },
  { id: 2, name: 'Carl', age: 41, genre: 'Jazz' },
  { id: 3, name: 'Rita', age: 40, genre: 'Rock' }
]

const groups = collect(people)
  .groupBy(person => ({ age: person.age, genre: person.genre }), true)
  .map(([key, people]) => [key, people.length])
  .all()

console.log(JSON.stringify(groups, null, 2))

/* Prints
[
  [
    {
      "age": 40,
      "genre": "Rock"
    },
    2
  ],
  [
    {
      "age": 41,
      "genre": "Jazz"
    },
    1
  ]
]
*/
```
I use my library quite a bit, but would love to switch over to using a fluent API such as this.