### PR TITLE
Return a random value if no length was specified

### DIFF
--- a/src/methods/random.js
+++ b/src/methods/random.js
@@ -1,14 +1,8 @@
 'use strict';
 
 module.exports = function random(length) {
-  const randomItemFromArray = this.slice(0);
-  randomItemFromArray.shuffle();
+  length = length || 1;
+  const randomCollection = this.slice().shuffle().take(length);
 
-  if (length !== undefined || length === 1) {
-    randomItemFromArray.items.splice(0, randomItemFromArray.items.length - length);
-
-    return randomItemFromArray;
-  }
-
-  return this.items[0];
+  return length === 1 ? randomCollection.first() : randomCollection;
 };


### PR DESCRIPTION
The previous implementation of random would always return the first item in the array if no length was specified. That is `collect([1,2,3,4,5]).random()` would always return 1. This fixes it.