### PR TITLE
Fix early return with every

### DIFF
--- a/src/methods/every.js
+++ b/src/methods/every.js
@@ -1,10 +1,12 @@
 'use strict';
 
 module.exports = function every(fn) {
-  for (let i = 0; i < this.items.length; i++) {
-    if (!fn(this.items[i])) {
+  let index = 0;
+  for (const item of this.items) {
+    if (! fn(item, index++)) {
       return false;
     }
-    return true;
   }
+
+  return true;
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -1016,7 +1016,12 @@ describe('Collect.js Test Suite', function () {
       return value > 2;
     });
 
+    const shouldBeFalse2 = collection.every(function (value, key) {
+      return value < 2;
+    });
+
     expect(shouldBeFalse).to.eql(false);
+    expect(shouldBeFalse2).to.eql(false);
 
     const shouldBeTrue = collection.every(function (value, key) {
       return value <= 4;


### PR DESCRIPTION
`every()` was only testing the first element before deciding whether to return which was a bit overzealous. I added a test case to show it. It should work correctly now.