### PR TITLE
Riching where condition by adding `<>` operation

### DIFF
--- a/src/methods/where.js
+++ b/src/methods/where.js
@@ -16,6 +16,7 @@ module.exports = function where(key, operator, value) {
           return item[key] === value;
 
         case '!=':
+        case '<>':
           return item[key] != value;
 
         case '!==':


### PR DESCRIPTION
Some SQLers may be used to write `<>` instead of `!=`.
In order to make codes more robust, may be we should take `<>` into account.
That operation has the same meaning with `!=`.