### PR TITLE
Improve documentation for macro method

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,7 @@ collection.all();
 
 //=> ['A', 'B', 'C']
 ```
+> Note that the `macro` method returns `undefined`, and therefore it is not possible to use it within a chain of methods.
 
 #### ``map()``
 The map method iterates through the collection and passes each value to the given callback. The callback is free to modify the item and return it, thus forming a new collection of modified items:


### PR DESCRIPTION
This PR includes a small documentation change elaborating on the usage of the `macro` method. I decided to add this in to highlight that it doesn't return a collection if used within a pipeline.

I understand that this is expected behaviour, but wanted to make it more obvious as it caught me out when trying to chain methods following `macro('x', fn)`.