### PR TITLE
Added missing key parameter to mapToGroups

### DIFF
--- a/src/methods/mapToGroups.js
+++ b/src/methods/mapToGroups.js
@@ -3,8 +3,8 @@
 module.exports = function mapToGroups(fn) {
   const collection = {};
 
-  this.items.forEach((item) => {
-    const [keyed, value] = fn(item);
+  this.items.forEach((item, key) => {
+    const [keyed, value] = fn(item, key);
 
     if (collection[keyed] === undefined) {
       collection[keyed] = [value];


### PR DESCRIPTION
The key parameter was missing for the mapToGroups function. This brings it into parity with [Laravel's mapToGroups function](https://laravel.com/docs/5.5/collections#method-maptogroups), as well as the [Collect.js own documenation](https://github.com/ecrmnn/collect.js#maptogroups).