### PR TITLE
dd was producing output inconsistent with Laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ The dd method will console.log the collection and exit the current process:
 ```js
 const collection = collect([1, 2, 3]).dd();
 
-//=> [1, 2, 3]
+//=> Collection { items: [ 1, 2, 3 ] }
 //=> (Exits node.js process)
 ```
 
@@ -363,8 +363,8 @@ collect([1, 2, 3, 4])
   .map(item => item * 2)
   .dump();
 
-//=> [1, 2, 3, 4]
-//=> [2, 4, 6, 8]
+//=> Collection { items: [ 1, 2, 3, 4 ] }
+//=> Collection { items: [ 2, 4, 6, 8 ] }
 ```
 
 #### ``each()``

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "uglify": "node_modules/.bin/uglifyjs build/collect.js --compress --mangle --output build/collect.min.js",
     "build": "npm run transpile && npm run bundle && npm run uglify",
     "eslint": "node_modules/.bin/eslint src/ test/",
-    "coverage": "node_modules/.bin/nyc mocha test/tests.js",
+    "coverage": "npm run transpile && node_modules/.bin/nyc mocha test/tests.js",
     "reporter": "node_modules/.bin/nyc report --reporter=html",
     "prepublishOnly": "npm run build"
   },

--- a/src/methods/dd.js
+++ b/src/methods/dd.js
@@ -1,8 +1,7 @@
 'use strict';
 
 module.exports = function dd() {
-  // eslint-disable-next-line
-  console.log(this.all());
+  this.dump();
 
   if (typeof process !== 'undefined') {
     process.exit(1);

--- a/test/methods/dd_test.js
+++ b/test/methods/dd_test.js
@@ -12,7 +12,7 @@ module.exports = (it, expect, collect) => {
     mockConsole.reset();
     mockProcess.reset();
 
-    expect(mockConsole.calls).to.eql([[[1, 2, 3]]]);
+    expect(mockConsole.calls).to.eql([[collect([1, 2, 3])]]);
     expect(mockProcess.calls).to.eql([[1]]);
   });
 };


### PR DESCRIPTION
- `dd` is now consistent with Laravel
- documentation will now show the actual output from `dump` and `dd`
- running `npm run coverage` did not test current code. This caused Travis build to fail.