### PR TITLE
Added overload declaration for filter method.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,8 @@ declare module 'collect.js' {
      * The filter method filters the collection using the given callback,
      * keeping only those items that pass a given truth test.
      */
-    filter(fn: (item: Item) => boolean): Collection<Item>;
+	filter(fn: (item: Item) => boolean): Collection<Item>;
+	filter(fn: (item: Item, key?: any) => boolean): Collection<Item>;
 
     /**
      * The first method returns the first element in the collection that passes a given truth test.


### PR DESCRIPTION
Fixed typescript warning when using the filter method with 2 parameters.
May help with Issue #184  

Commit details:
> Added overload declaration for filter method.
> It has an optional parameter (key?: any) that will store the Item key.