### PR TITLE
Consider "0" a valid key (that can be grouped).

### DIFF
--- a/dist/methods/groupBy.js
+++ b/dist/methods/groupBy.js
@@ -10,8 +10,10 @@ module.exports = function groupBy(key) {
 
     if (typeof key === 'function') {
       resolvedKey = key(item, index);
+    } else if (item[key] || item[key] === 0) {
+      resolvedKey = item[key];
     } else {
-      resolvedKey = item[key] || '';
+      resolvedKey = '';
     }
 
     if (collection[resolvedKey] === undefined) {

--- a/src/methods/groupBy.js
+++ b/src/methods/groupBy.js
@@ -8,8 +8,10 @@ module.exports = function groupBy(key) {
 
     if (typeof key === 'function') {
       resolvedKey = key(item, index);
+    } else if (item[key] || item[key] === 0) {
+      resolvedKey = item[key];
     } else {
-      resolvedKey = item[key] || '';
+      resolvedKey = '';
     }
 
     if (collection[resolvedKey] === undefined) {

--- a/test/methods/groupBy_test.js
+++ b/test/methods/groupBy_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const products = [
+  { product: 'Catalog', manufacturer: 'IKEA', price: 0 },
   { product: 'Desk', manufacturer: 'IKEA', price: 60 },
   { product: 'Chair', manufacturer: 'IKEA', price: 60 },
   { product: 'Lamp', manufacturer: 'IKEA', price: 15 },
@@ -23,6 +24,7 @@ module.exports = (it, expect, collect) => {
 
     expect(grouped.all()).to.eql({
       IKE: collect([
+        { product: 'Catalog', manufacturer: 'IKEA', price: 0 },
         { product: 'Desk', manufacturer: 'IKEA', price: 60 },
         { product: 'Chair', manufacturer: 'IKEA', price: 60 },
         { product: 'Lamp', manufacturer: 'IKEA', price: 15 },
@@ -40,6 +42,7 @@ module.exports = (it, expect, collect) => {
     const grouped = collection.groupBy('manufacturer');
 
     expect(grouped.first().all()).to.eql([
+      { product: 'Catalog', manufacturer: 'IKEA', price: 0 },
       { product: 'Desk', manufacturer: 'IKEA', price: 60 },
       { product: 'Chair', manufacturer: 'IKEA', price: 60 },
       { product: 'Lamp', manufacturer: 'IKEA', price: 15 },
@@ -59,6 +62,9 @@ module.exports = (it, expect, collect) => {
       const grouped = collection.groupBy('price');
 
       expect(grouped.all()).to.eql({
+        0: collect([
+          { product: 'Catalog', manufacturer: 'IKEA', price: 0 },
+        ]),
         15: collect([
           { product: 'Lamp', manufacturer: 'IKEA', price: 15 },
         ]),


### PR DESCRIPTION
This resolves an issue where `0` is being grouped in with other keys that are considered `undefined`, when `0` is very much so a valid key, and should be grouped accordingly.