### PR TITLE
Fixed a typo in splice documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,17 +1811,6 @@ collection.all();
 
 //=> [1, 2, 4, 5]
 ```
-
-#### ``split()``
-The split method breaks a collection into the given number of groups:
-```js
-const collection = collect([1, 2, 3, 4, 5]);
-
-const groups = collection.split(3);
-
-//=> [[1, 2], [3, 4], [5]]
-```
-
 In addition, you can pass a third argument containing the new items to replace the items removed from the collection:
 ```js
 const collection = collect([1, 2, 3, 4, 5]);
@@ -1835,6 +1824,16 @@ chunk.all()
 collection.all();
 
 //=> [1, 2, 10, 11, 4, 5]
+```
+
+#### ``split()``
+The split method breaks a collection into the given number of groups:
+```js
+const collection = collect([1, 2, 3, 4, 5]);
+
+const groups = collection.split(3);
+
+//=> [[1, 2], [3, 4], [5]]
 ```
 
 #### ``sum()``


### PR DESCRIPTION
The 3rd example for splice was accidentally under split.
The diff is quite annoying to read, so just look at the actual file on my branch https://github.com/dogoku/collect.js/tree/patch-1#splice