### PR TITLE
Improve clone helper to avoid modify original input 

### DIFF
--- a/dist/helpers/clone.js
+++ b/dist/helpers/clone.js
@@ -9,22 +9,25 @@
  * @returns {*}
  */
 
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
-
 module.exports = function clone(items) {
   var cloned = void 0;
-
   if (Array.isArray(items)) {
-    var _cloned;
-
     cloned = [];
-
-    (_cloned = cloned).push.apply(_cloned, _toConsumableArray(items));
+    items.forEach(function (value) {
+      if (value !== Object(value)) {
+        cloned.push(value);
+      } else {
+        cloned.push(clone(value));
+      }
+    });
   } else {
     cloned = {};
-
     Object.keys(items).forEach(function (prop) {
-      cloned[prop] = items[prop];
+      if (items[prop] instanceof Object) {
+        cloned[prop] = clone(items[prop]);
+      } else {
+        cloned[prop] = items[prop];
+      }
     });
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,13 +2,15 @@
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
+var clone = require('./helpers/clone');
+
 function Collection(collection) {
   if (collection !== undefined && !Array.isArray(collection) && (typeof collection === 'undefined' ? 'undefined' : _typeof(collection)) !== 'object') {
     this.items = [collection];
   } else if (collection instanceof this.constructor) {
-    this.items = collection.all();
+    this.items = clone(collection.all());
   } else {
-    this.items = collection || [];
+    this.items = clone(collection) || [];
   }
 }
 

--- a/src/helpers/clone.js
+++ b/src/helpers/clone.js
@@ -10,16 +10,23 @@
  */
 module.exports = function clone(items) {
   let cloned;
-
   if (Array.isArray(items)) {
     cloned = [];
-
-    cloned.push(...items);
+    items.forEach((value) => {
+      if (value !== Object(value)) {
+        cloned.push(value);
+      } else {
+        cloned.push(clone(value));
+      }
+    });
   } else {
     cloned = {};
-
     Object.keys(items).forEach((prop) => {
-      cloned[prop] = items[prop];
+      if (items[prop] instanceof Object) {
+        cloned[prop] = clone(items[prop]);
+      } else {
+        cloned[prop] = items[prop];
+      }
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 'use strict';
 
+const clone = require('./helpers/clone');
+
 function Collection(collection) {
   if (collection !== undefined && !Array.isArray(collection) && typeof collection !== 'object') {
     this.items = [collection];
   } else if (collection instanceof this.constructor) {
-    this.items = collection.all();
+    this.items = clone(collection.all());
   } else {
-    this.items = collection || [];
+    this.items = clone(collection) || [];
   }
 }
 

--- a/test/methods/clone_test.js
+++ b/test/methods/clone_test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+module.exports = (it, expect, collect) => {
+  const users = [
+    {
+      id: 1,
+      name: 'John',
+      sex: 'male',
+      age: 20,
+      companies: [{ name: 'Appl Inc' }, { name: 'Microsof Inc' }],
+      stat: {
+        weight: 64,
+        height: 174,
+      },
+    },
+    {
+      id: 2,
+      name: 'Vuvuzela',
+      sex: 'female',
+      age: 30,
+      companies: [{ name: 'Amazo Inc' }, { name: 'Alibab Inc' }],
+      stat: {
+        weight: 50,
+        height: 164,
+      },
+    },
+  ];
+
+  it('return items, but not modified the original', () => {
+    const collectUsers = collect(users);
+    const newUser = {
+      id: 3,
+      name: 'Vinmart',
+      sex: 'male',
+      age: 51,
+      companies: [{ name: 'VinGrou Inc' }],
+      stat: {
+        weight: 70,
+        height: 170,
+      },
+    };
+    collectUsers.push(newUser);
+    expect(users.length).to.be.equal(2);
+    expect(collectUsers.all().length).to.be.equal(3);
+  });
+
+  it('return items, but not modified properties of the original', () => {
+    const filter = collect(users)
+      .where('age', '>=', 20)
+      .first();
+    filter.name = 'Anna';
+    expect(filter.id).to.be.equal(1);
+    expect(filter.id).to.be.equal(users[0].id);
+    expect(users[0].name).to.be.equal('John');
+  });
+
+  it('return items, but not modified child properties of the original', () => {
+    const filter = collect(users)
+      .where('age', '>=', 20)
+      .first();
+    filter.companies[0].name = 'Unileve Inc';
+    expect(filter.id).to.be.equal(1);
+    expect(filter.id).to.be.equal(users[0].id);
+    expect(users[0].companies[0].name).to.be.equal('Appl Inc');
+  });
+};


### PR DESCRIPTION
I discovered an issue when retrieve result from collect. It can be modified the original input.
```
var users = [{name: "John", age: 30}, {name: "Steve", age: 20}];
var first = collect(users).where('age', 30).first();
first.age = 20;
users[0].age == 20; // true
```