### PR TITLE
Add return false code in '.each' function example

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,9 @@ const collection = collect([1, 3, 3, 7]);
 
 collection.each((item) => {
   sum += item;
+  if(sum > 5) {
+    return false;
+  }
 });
 
 // console.log(sum);


### PR DESCRIPTION
The README.md file, **.each function** section. The doc mentions about using `return false` to break from **.each function** but there is no `return false` in the example.

This PR adds the missing `return false` to make the doc more reliable.