### PR TITLE
Add chunkWhile

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ All available methods
 - [average](#average)
 - [avg](#avg)
 - [chunk](#chunk)
+- [chunkWhile](#chunkWhile)
 - [collapse](#collapse)
 - [combine](#combine)
 - [concat](#concat)
@@ -242,6 +243,32 @@ const chunks = collection.chunk(4);
 chunks.all();
 
 // [[1, 2, 3, 4], [5, 6, 7]]
+```
+
+#### `chunkWhile()`
+
+The chunkWhile method breaks the collection into multiple, smaller collections based on the evaluation of the given function:
+
+```js
+const collection = collect(['A', 'A', 'B', 'B', 'C', 'C', 'C', 'D']);
+
+const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+
+chunks.all();
+
+// [['A', 'A'], ['B', 'B'], ['C', 'C', 'C'], ['D']]
+```
+
+An empty collection is returned when `chunkWhile` is applied on an empty collection:
+
+```js
+const collection = collect([]);
+
+const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+
+chunks.all();
+
+// []
 ```
 
 #### `collapse()`

--- a/dist/index.js
+++ b/dist/index.js
@@ -34,6 +34,7 @@ Collection.prototype.all = require('./methods/all');
 Collection.prototype.average = require('./methods/average');
 Collection.prototype.avg = require('./methods/avg');
 Collection.prototype.chunk = require('./methods/chunk');
+Collection.prototype.chunkWhile = require('./methods/chunkWhile');
 Collection.prototype.collapse = require('./methods/collapse');
 Collection.prototype.combine = require('./methods/combine');
 Collection.prototype.concat = require('./methods/concat');

--- a/dist/methods/chunkWhile.js
+++ b/dist/methods/chunkWhile.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var _require = require('../helpers/is'),
+    isArray = _require.isArray,
+    isObject = _require.isObject;
+
+module.exports = function chunkWhile(fn) {
+    var chunks = [];
+    var index = 0;
+
+    if (isArray(this.items) && this.items.length === 0) {
+        return new this.constructor([]);
+    }
+
+    if (isObject(this.items) && Object.keys(this.items).length === 0) {
+        return new this.constructor({});
+    }
+
+    if (isArray(this.items)) {
+        var chunk = new this.constructor([]);
+
+        chunk.push(this.items[index]);
+
+        index++;
+
+        while (index < this.items.length) {
+            if (!fn(this.items[index], index, chunk)) {
+                chunks.push(chunk);
+
+                chunk = new this.constructor([]);
+            }
+
+            chunk.push(this.items[index]);
+
+            index++;
+        }
+
+        if (chunk.isNotEmpty()) {
+            chunks.push(chunk);
+        }
+    } else if (isObject(this.items)) {
+        var keys = Object.keys(this.items);
+
+        var _chunk = new this.constructor({});
+
+        _chunk.put(keys[index], this.items[keys[index]]);
+
+        index++;
+
+        while (index < keys.length) {
+            if (!fn(this.items[keys[index]], keys[index], _chunk)) {
+                chunks.push(_chunk);
+
+                _chunk = new this.constructor({});
+            }
+
+            _chunk.put(keys[index], this.items[keys[index]]);
+
+            index++;
+        }
+
+        if (_chunk.isNotEmpty()) {
+            chunks.push(_chunk);
+        }
+    } else {
+        chunks.push(new this.constructor([this.items]));
+    }
+
+    return new this.constructor(chunks);
+};

--- a/docs/api/chunkWhile.md
+++ b/docs/api/chunkWhile.md
@@ -1,0 +1,27 @@
+# `chunkWhile()`
+
+The chunkWhile method breaks the collection into multiple, smaller collections based on the evaluation of the given function:
+
+```js
+const collection = collect(['A', 'A', 'B', 'B', 'C', 'C', 'C', 'D']);
+
+const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+
+chunks.all();
+
+// [['A', 'A'], ['B', 'B'], ['C', 'C', 'C'], ['D']]
+```
+
+An empty collection is returned when `chunkWhile` is applied on an empty collection:
+
+```js
+const collection = collect([]);
+
+const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+
+chunks.all();
+
+// []
+```
+
+[View source on GitHub](https://github.com/ecrmnn/collect.js/blob/master/src/methods/chunkWhile.js)

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ Collection.prototype.all = require('./methods/all');
 Collection.prototype.average = require('./methods/average');
 Collection.prototype.avg = require('./methods/avg');
 Collection.prototype.chunk = require('./methods/chunk');
+Collection.prototype.chunkWhile = require('./methods/chunkWhile');
 Collection.prototype.collapse = require('./methods/collapse');
 Collection.prototype.combine = require('./methods/combine');
 Collection.prototype.concat = require('./methods/concat');

--- a/src/methods/chunkWhile.js
+++ b/src/methods/chunkWhile.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { isArray, isObject } = require('../helpers/is');
+
+module.exports = function chunkWhile(fn) {
+    const chunks = [];
+    let index = 0;
+
+    if (isArray(this.items) && this.items.length === 0) {
+        return new this.constructor([]);
+    }
+
+    if (isObject(this.items) && Object.keys(this.items).length === 0) {
+        return new this.constructor({});
+    }
+
+    if (isArray(this.items)) {
+        let chunk = new this.constructor([]);
+
+        chunk.push(this.items[index]);
+
+        index++;
+
+        while (index < this.items.length) {
+            if (!fn(this.items[index], index, chunk)) {
+                chunks.push(chunk);
+
+                chunk = new this.constructor([]);
+            }
+
+            chunk.push(this.items[index]);
+
+            index++;
+        }
+
+        if (chunk.isNotEmpty()) {
+            chunks.push(chunk);
+        }
+
+    } else if (isObject(this.items)) {
+        const keys = Object.keys(this.items);
+
+        let chunk = new this.constructor({});
+
+        chunk.put(keys[index], this.items[keys[index]]);
+
+        index++;
+
+        while (index < keys.length) {
+            if (!fn(this.items[keys[index]], keys[index], chunk)) {
+                chunks.push(chunk);
+
+                chunk = new this.constructor({});
+            }
+
+            chunk.put(keys[index], this.items[keys[index]]);
+
+            index++;
+        }
+
+        if (chunk.isNotEmpty()) {
+            chunks.push(chunk);
+        }
+
+    } else {
+        chunks.push(new this.constructor([this.items]));
+    }
+
+    return new this.constructor(chunks);
+};

--- a/test/methods/chunkWhile_test.js
+++ b/test/methods/chunkWhile_test.js
@@ -1,0 +1,216 @@
+'use strict';
+
+module.exports = (it, expect, collect) => {
+    it('should break the collection into multiple collections of elements', () => {
+        const collection = collect(['A', 'A', 'B', 'B', 'C', 'C', 'C', 'D']);
+
+        const chunksOf1 = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+        expect(chunksOf1.all()).to.eql([
+            collect(['A', 'A']),
+            collect(['B', 'B']),
+            collect(['C', 'C', 'C']),
+            collect(['D'])
+        ]);
+
+        const chunksOf2 = collection.chunkWhile((current, key, chunk) => current !== chunk.last());
+        expect(chunksOf2.all()).to.eql([
+            collect(['A']),
+            collect(['A', 'B']),
+            collect(['B', 'C']),
+            collect(['C']),
+            collect(['C', 'D'])
+        ]);
+    });
+
+    it('should break the collection into multiple collections of contiguously increasing integers', () => {
+        const collection = collect([1, 4, 9, 10, 11, 12, 15, 16, 19, 20, 21]);
+
+        const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last() + 1);
+        expect(chunks.all()).to.eql([
+            collect([1]),
+            collect([4]),
+            collect([9, 10, 11, 12]),
+            collect([15, 16]),
+            collect([19, 20, 21])
+        ]);
+    });
+
+    it('should break the collection into multiple collections of increasing order of elements', () => {
+        const collection = collect([30, 32, 35, 20, 23, 29, 12, 14, 17]);
+
+        const chunks = collection.chunkWhile((current, key, chunk) => current > chunk.last());
+        expect(chunks.all()).to.eql([
+            collect([30, 32, 35]),
+            collect([20, 23, 29]),
+            collect([12, 14, 17])
+        ]);
+    });
+
+    it('should return a new collection, not modify the original', () => {
+        const collection = collect([1, 2, 3, 4]);
+        const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+
+        expect(chunks.all()).to.eql([
+            collect([1]),
+            collect([2]),
+            collect([3]),
+            collect([4]),
+        ]);
+
+        expect(collection.all()).to.eql([1, 2, 3, 4]);
+
+        expect(chunks).to.not.eql(collection);
+    });
+
+    it('should return an empty collection when empty collection is passed', () => {
+        const collection = collect([]);
+        const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+
+        expect(chunks.all()).to.eql([]);
+    });
+
+    it('should return a new collection with specified value in chunk when a value is passed', () => {
+        const collection = collect(1);
+        const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+
+        expect(chunks.all()).to.eql([
+            collect([1])
+        ]);
+    });
+
+    it('should break the collection based on object into multiple collections of elements', () => {
+        const collection = collect({
+            first: 'A',
+            second: 'A',
+            third: 'B',
+            fourth: 'B',
+            fifth: 'C',
+            sixth: 'C',
+            seventh: 'C',
+            eighth: 'D',
+        });
+
+        const chunksOf1 = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+        expect(chunksOf1.all()).to.eql([
+            collect({
+                first: 'A',
+                second: 'A',
+            }),
+            collect({
+                third: 'B',
+                fourth: 'B',
+            }),
+            collect({
+                fifth: 'C',
+                sixth: 'C',
+                seventh: 'C',
+            }),
+            collect({
+                eighth: 'D',
+            })
+        ]);
+
+        const chunksOf2 = collection.chunkWhile((current, key, chunk) => current !== chunk.last());
+        expect(chunksOf2.all()).to.eql([
+            collect({
+                first: 'A',
+            }),
+            collect({
+                second: 'A',
+                third: 'B',
+            }),
+            collect({
+                fourth: 'B',
+                fifth: 'C',
+            }),
+            collect({
+                sixth: 'C',
+            }),
+            collect({
+                seventh: 'C',
+                eighth: 'D',
+            })
+        ]);
+    });
+
+    it('should break the collection based on object into multiple collections of contiguously increasing integers', () => {
+        const collection = collect({
+            first: 1,
+            second: 4,
+            third: 9,
+            fourth: 10,
+            fifth: 11,
+            sixth: 12,
+            seventh: 15,
+            eighth: 16,
+            ninth: 19,
+            tenth: 20,
+            eleventh: 21,
+        });
+
+        const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last() + 1);
+        expect(chunks.all()).to.eql([
+            collect({
+                first: 1,
+            }),
+            collect({
+                second: 4,
+            }),
+            collect({
+                third: 9,
+                fourth: 10,
+                fifth: 11,
+                sixth: 12,
+            }),
+            collect({
+                seventh: 15,
+                eighth: 16,
+            }),
+            collect({
+                ninth: 19,
+                tenth: 20,
+                eleventh: 21,
+            })
+        ]);
+    });
+
+    it('should break the collection based on object into multiple collections of increasing order of elements', () => {
+        const collection = collect({
+            first: 30,
+            second: 32,
+            third: 35,
+            fourth: 20,
+            fifth: 23,
+            sixth: 29,
+            seventh: 12,
+            eighth: 14,
+            ninth: 17,
+        });
+
+        const chunks = collection.chunkWhile((current, key, chunk) => current > chunk.last());
+        expect(chunks.all()).to.eql([
+            collect({
+                first: 30,
+                second: 32,
+                third: 35,
+            }),
+            collect({
+                fourth: 20,
+                fifth: 23,
+                sixth: 29,
+            }),
+            collect({
+                seventh: 12,
+                eighth: 14,
+                ninth: 17,
+            })
+        ]);
+    });
+
+    it('should return an empty collection when empty collection based on object is passed', () => {
+        const collection = collect({});
+        const chunks = collection.chunkWhile((current, key, chunk) => current === chunk.last());
+
+        expect(chunks.all()).to.eql({});
+    });
+};


### PR DESCRIPTION
- The `chunkWhile` method breaks the collection into multiple, smaller
collections based on the evaluation of the given function.

- It was added in Laravel 8.x (https://laravel.com/docs/8.x/collections#method-chunkwhile)