### PR TITLE
Typescript: sum() is supposed to be returning `number`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -398,7 +398,7 @@ declare module 'collect.js' {
     /**
      * The sum method returns the sum of all items in the collection.
      */
-    sum<K>(key?: keyof Item | K | ((item: Item) => number | string)): number | string;
+    sum<K>(key?: keyof Item | K | ((item: Item) => number | string)): number;
 
     [Symbol.iterator]: () => Iterator<Item>;
 


### PR DESCRIPTION
Hi,

I looked into the source code and `sum()` uses parseFloat meaning it always returns Number. But Typescript returning 
`string | number`. I made a PR to fix this issue in TS. 