### PR TITLE
Pass the key with mapWithKeys

### DIFF
--- a/src/methods/mapWithKeys.js
+++ b/src/methods/mapWithKeys.js
@@ -4,13 +4,13 @@ module.exports = function mapWithKeys(fn) {
   const collection = {};
 
   if (Array.isArray(this.items)) {
-    this.items.forEach((item) => {
-      const [keyed, value] = fn(item);
+    this.items.forEach((item, index) => {
+      const [keyed, value] = fn(item, index);
       collection[keyed] = value;
     });
   } else {
     Object.keys(this.items).forEach((key) => {
-      const [keyed, value] = fn(this.items[key]);
+      const [keyed, value] = fn(this.items[key], key);
       collection[keyed] = value;
     });
   }


### PR DESCRIPTION
By exposing the keys from the collection in the callback we can more easily transform its keys.