### PR TITLE
Add `firstOr` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,30 @@ collect([1, 2, 3, 4]).first();
 // 1
 ```
 
+#### `firstOr()`
+
+The firstOr method returns the first element in the collection or the default value:
+
+```js
+collect().firstOr(5);
+
+// 5
+```
+
+```js
+collect([1, 2, 3, 4]).firstOr(5);
+
+// 1
+```
+
+You may also supply a callback as the default value:
+
+```js
+collect().firstOr(() => {
+  throw new Error('...');
+});
+```
+
 #### `firstWhere()`
 
 The firstWhere method returns the first element in the collection with the given key / value pair:

--- a/docs/api/firstOr.md
+++ b/docs/api/firstOr.md
@@ -1,0 +1,23 @@
+#### `firstOr()`
+
+The firstOr method returns the first element in the collection or the default value:
+
+```js
+collect().firstOr(5);
+
+// 5
+```
+
+```js
+collect([1, 2, 3, 4]).firstOr(5);
+
+// 1
+```
+
+You may also supply a callback as the default value:
+
+```js
+collect().firstOr(() => {
+  throw new Error('...');
+});
+```

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ Collection.prototype.every = require('./methods/every');
 Collection.prototype.except = require('./methods/except');
 Collection.prototype.filter = require('./methods/filter');
 Collection.prototype.first = require('./methods/first');
+Collection.prototype.firstOr = require('./methods/firstOr');
 Collection.prototype.firstWhere = require('./methods/firstWhere');
 Collection.prototype.flatMap = require('./methods/flatMap');
 Collection.prototype.flatten = require('./methods/flatten');

--- a/src/methods/firstOr.js
+++ b/src/methods/firstOr.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function firstOr(fn) {
+  return this.first(null, fn) || null;
+};

--- a/test/methods/firstOr_test.js
+++ b/test/methods/firstOr_test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = (it, expect, collect) => {
+  it('should return the first value', () => {
+    const collection = collect([1]);
+
+    expect(collection.firstOr()).to.eq(1);
+  })
+
+  it('should return null with no default value', () => {
+    const collection = collect();
+
+    expect(collection.firstOr()).to.eq(null);
+  });
+
+  it('should return the default value', () => {
+    const collection = collect();
+    const first = collection.firstOr('foo');
+
+    expect(first).to.eq('foo');
+  });
+
+  it('should return the callback value', () => {
+    const collection = collect();
+    const first = collection.firstOr(() => 'foo');
+
+    expect(first).to.eql('foo');
+  });
+};


### PR DESCRIPTION
## Description

This PR introduces the `firstOr()` method, which simplifies `first()` calls so you no longer have to pass in `null` as the first parameter.

## Examples

**Before**:
```js
collect().first(null, 'default')

// default
```

**After**:
```js
collect().firstOr('default');

// default
```

**With callback**:

```js
collect([1, 2, 3, 4])
    .where(value => value === 5)
    .firstOr(() => {
        throw new Error('Item not found.');
    });

// Throws error.
```

No hard feelings on closure. I love this library and I really appreciate your hard work on this ❤️ 

---

Maybe we could also introduce a `firstOrFail()` as well that would throw an error when an item isn't found? What are your thoughts/opinion on this? I can submit a PR if you give the go ahead 👍 

```js
// firstOrFail.js

module.exports = function () {
    return this.firstOr(() => {
        throw new Error('Item not found.');
    });
};

// Usage

collect().firstOrFail();
```