### PR TITLE
Fix `each` typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,7 @@ declare module 'collect.js' {
     /**
      * The each method iterates over the items in the collection and passes each item to a callback.
      */
-    each(fn: (currentItem: Item, key?: number, collection?: Item[]) => void): this;
+    each(fn: (currentItem: Item, key?: string | number, collection?: Item[]) => void): this;
 
     /**
      * The every method may be used to verify that all elements of a collection pass a given truth test.

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,7 @@ declare module 'collect.js' {
     /**
      * The each method iterates over the items in the collection and passes each item to a callback.
      */
-    each(fn: (item: Item) => void, index?: number, items?: Item[]): this;
+    each(fn: (currentItem: Item, key?: number, collection?: Item[]) => void): this;
 
     /**
      * The every method may be used to verify that all elements of a collection pass a given truth test.


### PR DESCRIPTION
There was three parameters, while `each` takes one parameter: a callback with three parameters (the ones that were in the each function and not in the callback).  
Also, parameters names have been made fancier!

Examples:

Before:

```javascript
collect({}).each(item => ..., index, items);
```

After:

```javascript
collect({}).each((currentItem, key, collection) => ...);
```