### PR TITLE
Allow all()'s return type to be an object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,9 +7,9 @@ declare module 'collect.js' {
     constructor(collection?: Item[] | Object);
 
     /**
-     * The all method returns the underlying array represented by the collection.
+     * The all method returns the underlying array or object represented by the collection.
      */
-    all(): Item[];
+    all(): Item[] | Record<string,Item>;
 
     /**
      * Alias for the avg() method.


### PR DESCRIPTION
Sometimes the return type of `all()` is an object, not an array