### PR TITLE
Improved `keys` method ts annotation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -199,7 +199,7 @@ declare module 'collect.js' {
     /**
      * The keys method returns all of the collection's keys.
      */
-    keys(): Collection<string>;
+    keys<T = string>(): Collection<T>;
 
     /**
      * The last method returns the last element in the collection that passes a given truth test.


### PR DESCRIPTION
In some cases, the keys may not be just strings, but strictly defined strings